### PR TITLE
feat: implement custom credential template management

### DIFF
--- a/src/components/modules/issue/hooks/useCredentialTemplates.ts
+++ b/src/components/modules/issue/hooks/useCredentialTemplates.ts
@@ -1,8 +1,11 @@
 'use client';
 import type { CredentialTemplate } from '@/@types/templates';
+import { useCustomTemplates } from './useCustomTemplates';
 
 export function useCredentialTemplates() {
-  const templates: CredentialTemplate[] = [
+  const { customTemplates, saveTemplate, deleteTemplate } = useCustomTemplates();
+
+  const builtIn: CredentialTemplate[] = [
     {
       id: 'escrow',
       title: 'Escrow',
@@ -104,5 +107,7 @@ export function useCredentialTemplates() {
     },
   ];
 
-  return { templates };
+  const templates: CredentialTemplate[] = [...builtIn, ...customTemplates];
+
+  return { templates, saveTemplate, deleteTemplate };
 }

--- a/src/components/modules/issue/hooks/useCustomTemplates.ts
+++ b/src/components/modules/issue/hooks/useCustomTemplates.ts
@@ -1,0 +1,84 @@
+'use client';
+
+import { useCallback, useSyncExternalStore } from 'react';
+import type { CredentialTemplate, TemplateField } from '@/@types/templates';
+
+const STORAGE_KEY = 'acta-custom-templates';
+const EMPTY: CredentialTemplate[] = [];
+
+let listeners: Array<() => void> = [];
+let cachedRaw: string | null = null;
+let cachedValue: CredentialTemplate[] = EMPTY;
+
+function readFromStorage(): CredentialTemplate[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw === cachedRaw) return cachedValue;
+    cachedRaw = raw;
+    cachedValue = raw ? (JSON.parse(raw) as CredentialTemplate[]) : EMPTY;
+    return cachedValue;
+  } catch {
+    return EMPTY;
+  }
+}
+
+function emitChange() {
+  readFromStorage();
+  for (const l of listeners) l();
+}
+
+function subscribe(cb: () => void) {
+  listeners = [...listeners, cb];
+  return () => {
+    listeners = listeners.filter((l) => l !== cb);
+  };
+}
+
+function getSnapshot(): CredentialTemplate[] {
+  return readFromStorage();
+}
+
+function getServerSnapshot(): CredentialTemplate[] {
+  return EMPTY;
+}
+
+function persist(templates: CredentialTemplate[]) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(templates));
+  emitChange();
+}
+
+const BASE_FIELDS: TemplateField[] = [
+  {
+    key: 'subject',
+    label: 'Subject DID',
+    type: 'did',
+    required: true,
+    placeholder: 'Wallet (G...) – we derive DID',
+  },
+  { key: 'issueDate', label: 'Issue Date', type: 'date', required: true },
+  { key: 'expirationDate', label: 'Expiration Date', type: 'date' },
+];
+
+export function useCustomTemplates() {
+  const customTemplates = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  const saveTemplate = useCallback(
+    (draft: { title: string; description: string; vcType: string; fields: TemplateField[] }) => {
+      const id = `custom-${Date.now().toString(36)}`;
+      const merged: TemplateField[] = [
+        ...BASE_FIELDS,
+        ...draft.fields.filter((f) => !BASE_FIELDS.some((b) => b.key === f.key)),
+      ];
+      const tpl: CredentialTemplate = { id, ...draft, fields: merged };
+      persist([...getSnapshot(), tpl]);
+      return tpl;
+    },
+    []
+  );
+
+  const deleteTemplate = useCallback((id: string) => {
+    persist(getSnapshot().filter((t) => t.id !== id));
+  }, []);
+
+  return { customTemplates, saveTemplate, deleteTemplate, BASE_FIELDS };
+}

--- a/src/components/modules/issue/ui/CustomTemplateBuilder.tsx
+++ b/src/components/modules/issue/ui/CustomTemplateBuilder.tsx
@@ -1,0 +1,245 @@
+'use client';
+
+import { useState } from 'react';
+import type { CredentialTemplate, TemplateField } from '@/@types/templates';
+
+type DraftField = Omit<TemplateField, 'key'> & { key?: string };
+
+const FIELD_TYPES: TemplateField['type'][] = ['text', 'number', 'date', 'email', 'did'];
+
+function toKey(label: string) {
+  return label
+    .trim()
+    .replace(/\s+(.)/g, (_, c: string) => c.toUpperCase())
+    .replace(/^(.)/, (_, c: string) => c.toLowerCase())
+    .replace(/[^a-zA-Z0-9]/g, '');
+}
+
+export default function CustomTemplateBuilder({
+  onSave,
+  onCancel,
+}: {
+  onSave: (draft: {
+    title: string;
+    description: string;
+    vcType: string;
+    fields: TemplateField[];
+  }) => CredentialTemplate;
+  onCancel: () => void;
+}) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [vcType, setVcType] = useState('');
+  const [fields, setFields] = useState<DraftField[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const addField = () => {
+    setFields((prev) => [...prev, { label: '', type: 'text', required: false, placeholder: '' }]);
+  };
+
+  const removeField = (idx: number) => {
+    setFields((prev) => prev.filter((_, i) => i !== idx));
+  };
+
+  const updateField = (idx: number, patch: Partial<DraftField>) => {
+    setFields((prev) => prev.map((f, i) => (i === idx ? { ...f, ...patch } : f)));
+  };
+
+  const handleSave = () => {
+    setError(null);
+    if (!title.trim()) {
+      setError('Template name is required');
+      return;
+    }
+    if (!vcType.trim()) {
+      setError('VC Type is required (e.g. CustomCredential)');
+      return;
+    }
+    for (const f of fields) {
+      if (!f.label.trim()) {
+        setError('All custom fields must have a label');
+        return;
+      }
+    }
+
+    const resolved: TemplateField[] = fields.map((f) => ({
+      ...f,
+      key: f.key || toKey(f.label),
+      label: f.label.trim(),
+    }));
+
+    const seen = new Set<string>();
+    for (const f of resolved) {
+      if (seen.has(f.key)) {
+        setError(`Duplicate field key "${f.key}"`);
+        return;
+      }
+      seen.add(f.key);
+    }
+
+    onSave({
+      title: title.trim(),
+      description: description.trim() || `Custom template: ${title.trim()}`,
+      vcType: vcType.trim(),
+      fields: resolved,
+    });
+  };
+
+  const inputClass =
+    'w-full rounded-xl border border-zinc-800 bg-zinc-950/50 text-white placeholder:text-zinc-500 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent transition-all';
+
+  return (
+    <div className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-6 backdrop-blur-sm space-y-5">
+      <h3 className="text-xl font-semibold text-white">Create Custom Template</h3>
+      <p className="text-sm text-zinc-400">
+        Subject DID, Issue Date and Expiration Date are always included automatically.
+      </p>
+
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-white mb-2">Template Name *</label>
+          <input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="e.g. Certification Badge"
+            className={inputClass}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-white mb-2">Description</label>
+          <input
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Brief description of this template"
+            className={inputClass}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-white mb-2">VC Type *</label>
+          <input
+            value={vcType}
+            onChange={(e) => setVcType(e.target.value)}
+            placeholder="e.g. CertificationCredential"
+            className={inputClass}
+          />
+          <p className="mt-1 text-xs text-zinc-500">
+            Used in the VC <code>type</code> array alongside &quot;VerifiableCredential&quot;.
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <label className="block text-sm font-medium text-white">Custom Fields</label>
+          <button
+            type="button"
+            onClick={addField}
+            className="rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-white hover:bg-zinc-700 transition-colors"
+          >
+            + Add Field
+          </button>
+        </div>
+
+        {fields.length === 0 && (
+          <p className="text-sm text-zinc-500 py-2">
+            No custom fields yet. Click &quot;+ Add Field&quot; to add one.
+          </p>
+        )}
+
+        {fields.map((f, idx) => (
+          <div
+            key={idx}
+            className="rounded-xl border border-zinc-800 bg-zinc-950/30 p-4 space-y-3"
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-medium text-zinc-400">Field {idx + 1}</span>
+              <button
+                type="button"
+                onClick={() => removeField(idx)}
+                className="text-xs text-red-400 hover:text-red-300 transition-colors"
+              >
+                Remove
+              </button>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-xs text-zinc-400 mb-1">Label *</label>
+                <input
+                  value={f.label}
+                  onChange={(e) => updateField(idx, { label: e.target.value })}
+                  placeholder="e.g. Organization"
+                  className={inputClass}
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-zinc-400 mb-1">Type</label>
+                <select
+                  value={f.type}
+                  onChange={(e) =>
+                    updateField(idx, { type: e.target.value as TemplateField['type'] })
+                  }
+                  className={inputClass}
+                >
+                  {FIELD_TYPES.map((t) => (
+                    <option key={t} value={t}>
+                      {t}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-xs text-zinc-400 mb-1">Placeholder</label>
+                <input
+                  value={f.placeholder || ''}
+                  onChange={(e) => updateField(idx, { placeholder: e.target.value })}
+                  placeholder="Optional hint"
+                  className={inputClass}
+                />
+              </div>
+              <div className="flex items-end pb-3">
+                <label className="flex items-center gap-2 text-sm text-white cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={f.required || false}
+                    onChange={(e) => updateField(idx, { required: e.target.checked })}
+                    className="h-4 w-4 rounded border border-zinc-700 bg-zinc-950/50 text-blue-600 focus:ring-blue-600"
+                  />
+                  Required
+                </label>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {error && (
+        <div className="text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-2">
+          {error}
+        </div>
+      )}
+
+      <div className="flex gap-3 pt-2">
+        <button
+          type="button"
+          onClick={handleSave}
+          className="flex-1 rounded-xl bg-white text-black px-6 py-3 font-medium hover:bg-gray-100 transition-all"
+        >
+          Save Template
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="flex-1 rounded-xl border border-zinc-700 bg-zinc-800 text-white px-6 py-3 font-medium hover:bg-zinc-700 transition-all"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/modules/issue/ui/CustomTemplateBuilder.tsx
+++ b/src/components/modules/issue/ui/CustomTemplateBuilder.tsx
@@ -149,10 +149,7 @@ export default function CustomTemplateBuilder({
         )}
 
         {fields.map((f, idx) => (
-          <div
-            key={idx}
-            className="rounded-xl border border-zinc-800 bg-zinc-950/30 p-4 space-y-3"
-          >
+          <div key={idx} className="rounded-xl border border-zinc-800 bg-zinc-950/30 p-4 space-y-3">
             <div className="flex items-center justify-between">
               <span className="text-xs font-medium text-zinc-400">Field {idx + 1}</span>
               <button

--- a/src/components/modules/issue/ui/IssueBuilder.tsx
+++ b/src/components/modules/issue/ui/IssueBuilder.tsx
@@ -1,38 +1,66 @@
 'use client';
 
+import { useState } from 'react';
+import { toast } from 'sonner';
 import { useCredentialTemplates } from '../hooks/useCredentialTemplates';
 import { useIssueCredential } from '../hooks/useIssueCredential';
 import DynamicIssueForm from './DynamicIssueForm';
 import TemplateSelector from './TemplateSelector';
+import CustomTemplateBuilder from './CustomTemplateBuilder';
 
 export default function IssueBuilder() {
-  const { templates } = useCredentialTemplates();
+  const { templates, saveTemplate, deleteTemplate } = useCredentialTemplates();
   const { state, apiKey, setApiKey, selectTemplate, setFieldValue, buildPreview, issue } =
     useIssueCredential();
 
+  const [showBuilder, setShowBuilder] = useState(false);
+
   return (
     <div className="space-y-6">
-      <TemplateSelector
-        templates={templates}
-        selectedId={state.template?.id || null}
-        onSelect={selectTemplate}
-      />
+      {showBuilder ? (
+        <CustomTemplateBuilder
+          onSave={(draft) => {
+            const tpl = saveTemplate(draft);
+            toast.success(`Template "${tpl.title}" saved`);
+            setShowBuilder(false);
+            selectTemplate(tpl);
+            return tpl;
+          }}
+          onCancel={() => setShowBuilder(false)}
+        />
+      ) : (
+        <>
+          <TemplateSelector
+            templates={templates}
+            selectedId={state.template?.id || null}
+            onSelect={selectTemplate}
+            onCreateCustom={() => setShowBuilder(true)}
+            onDeleteCustom={(id) => {
+              deleteTemplate(id);
+              if (state.template?.id === id) {
+                selectTemplate(templates.find((t) => !t.id.startsWith('custom-'))!);
+              }
+              toast.success('Custom template deleted');
+            }}
+          />
 
-      <DynamicIssueForm
-        template={state.template}
-        values={state.values}
-        vcId={state.vcId}
-        issuing={state.issuing}
-        preview={state.preview}
-        error={state.error}
-        apiKey={apiKey}
-        onSetApiKey={setApiKey}
-        onSetField={setFieldValue}
-        onBuildPreview={buildPreview}
-        onSubmit={async () => {
-          await issue();
-        }}
-      />
+          <DynamicIssueForm
+            template={state.template}
+            values={state.values}
+            vcId={state.vcId}
+            issuing={state.issuing}
+            preview={state.preview}
+            error={state.error}
+            apiKey={apiKey}
+            onSetApiKey={setApiKey}
+            onSetField={setFieldValue}
+            onBuildPreview={buildPreview}
+            onSubmit={async () => {
+              await issue();
+            }}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/modules/issue/ui/TemplateSelector.tsx
+++ b/src/components/modules/issue/ui/TemplateSelector.tsx
@@ -6,31 +6,80 @@ export default function TemplateSelector({
   templates,
   selectedId,
   onSelect,
+  onCreateCustom,
+  onDeleteCustom,
 }: {
   templates: CredentialTemplate[];
   selectedId: string | null;
   onSelect: (tpl: CredentialTemplate) => void;
+  onCreateCustom?: () => void;
+  onDeleteCustom?: (id: string) => void;
 }) {
+  const isCustom = (id: string) => id.startsWith('custom-');
+  const selectedIsCustom = selectedId ? isCustom(selectedId) : false;
+
   return (
-    <div className="space-y-2">
+    <div className="space-y-3">
       <label className="block mt-4 text-sm font-medium text-white">Select Template</label>
-      <select
-        value={selectedId || ''}
-        onChange={(e) => {
-          const tpl = templates.find((t) => t.id === e.target.value);
-          if (tpl) onSelect(tpl);
-        }}
-        className="w-full rounded-xl border border-zinc-800 bg-zinc-950/50 text-white px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent transition-all"
-      >
-        <option value="" disabled>
-          Choose a template...
-        </option>
-        {templates.map((tpl) => (
-          <option key={tpl.id} value={tpl.id}>
-            {tpl.title} - {tpl.description}
+
+      <div className="flex gap-3">
+        <select
+          value={selectedId || ''}
+          onChange={(e) => {
+            const tpl = templates.find((t) => t.id === e.target.value);
+            if (tpl) onSelect(tpl);
+          }}
+          className="flex-1 rounded-xl border border-zinc-800 bg-zinc-950/50 text-white px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent transition-all"
+        >
+          <option value="" disabled>
+            Choose a template...
           </option>
-        ))}
-      </select>
+
+          {templates.filter((t) => !isCustom(t.id)).length > 0 && (
+            <optgroup label="Built-in">
+              {templates
+                .filter((t) => !isCustom(t.id))
+                .map((tpl) => (
+                  <option key={tpl.id} value={tpl.id}>
+                    {tpl.title} – {tpl.description}
+                  </option>
+                ))}
+            </optgroup>
+          )}
+
+          {templates.filter((t) => isCustom(t.id)).length > 0 && (
+            <optgroup label="Custom">
+              {templates
+                .filter((t) => isCustom(t.id))
+                .map((tpl) => (
+                  <option key={tpl.id} value={tpl.id}>
+                    {tpl.title} – {tpl.description}
+                  </option>
+                ))}
+            </optgroup>
+          )}
+        </select>
+
+        {onCreateCustom && (
+          <button
+            type="button"
+            onClick={onCreateCustom}
+            className="shrink-0 rounded-xl border border-zinc-700 bg-zinc-800 px-4 py-3 text-sm text-white hover:bg-zinc-700 transition-colors"
+          >
+            + Custom
+          </button>
+        )}
+      </div>
+
+      {selectedIsCustom && onDeleteCustom && selectedId && (
+        <button
+          type="button"
+          onClick={() => onDeleteCustom(selectedId)}
+          className="text-xs text-red-400 hover:text-red-300 transition-colors"
+        >
+          Delete this custom template
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION

## Description
- Introduced `useCustomTemplates` hook for managing user-defined credential templates with local storage persistence.
- Enhanced `useCredentialTemplates` to integrate custom templates alongside built-in ones.
- Added `CustomTemplateBuilder` component for creating and editing custom templates.
- Updated `TemplateSelector` to support custom template creation and deletion.
- Modified `IssueBuilder` to incorporate the new custom template functionality, allowing users to create and select templates seamlessly.

## Type of Change

<!-- Please delete options that are not relevant. -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ x ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/formatting changes (no code change)
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Tests (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/config changes
- [ ] 🔒 Security fix









<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create, save and delete custom credential templates with personalized fields.
  * New template builder UI for defining template title, metadata and custom fields with validation.
  * Custom templates are shown separately from built‑in templates in the selector with a “+ Custom” flow.
  * Success and deletion notifications for template actions; selector auto-falls back if a selected custom template is removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->