### PR TITLE
fix: update proof handling in useShareCredential hook

### DIFF
--- a/src/components/modules/credentials/hooks/useCredentialVerify.ts
+++ b/src/components/modules/credentials/hooks/useCredentialVerify.ts
@@ -89,7 +89,11 @@ export function useCredentialVerify(vcId: string) {
           };
           setRevealed(sp.revealedFields || null);
           const st = sp.statement;
-          const hasSt = typeof st === 'object' && st && 'kind' in st && (st as { kind?: string }).kind !== 'none';
+          const hasSt =
+            typeof st === 'object' &&
+            st &&
+            'kind' in st &&
+            (st as { kind?: string }).kind !== 'none';
           const hasProof = typeof sp.proof === 'string' && sp.proof.length > 0;
           const hasZk = hasSt && hasProof;
           setHasZkProofInShare(hasZk);
@@ -155,5 +159,14 @@ export function useCredentialVerify(vcId: string) {
     }
   };
 
-  return { verify, revealed, zkValid, zkStatement, reverify, reverifyLoading, hasVerified, hasZkProofInShare };
+  return {
+    verify,
+    revealed,
+    zkValid,
+    zkStatement,
+    reverify,
+    reverifyLoading,
+    hasVerified,
+    hasZkProofInShare,
+  };
 }

--- a/src/components/modules/credentials/hooks/useCredentialVerify.ts
+++ b/src/components/modules/credentials/hooks/useCredentialVerify.ts
@@ -95,7 +95,7 @@ export function useCredentialVerify(vcId: string) {
             'kind' in st &&
             (st as { kind?: string }).kind !== 'none';
           const hasProof = typeof sp.proof === 'string' && sp.proof.length > 0;
-          const hasZk = hasSt && hasProof;
+          const hasZk = Boolean(hasSt && hasProof);
           setHasZkProofInShare(hasZk);
           if (hasZk) {
             setZkStatement(st as ZkStatement);

--- a/src/components/modules/credentials/hooks/useCredentialVerify.ts
+++ b/src/components/modules/credentials/hooks/useCredentialVerify.ts
@@ -25,6 +25,7 @@ export function useCredentialVerify(vcId: string) {
   const [hasVerified, setHasVerified] = useState(false);
   const [reverifyLoading, setReverifyLoading] = useState(false);
   const [shareParam, setShareParam] = useState<unknown>(null);
+  const [hasZkProofInShare, setHasZkProofInShare] = useState(false);
   useEffect(() => {
     const read = async () => {
       if (typeof window === 'undefined') return;
@@ -88,7 +89,11 @@ export function useCredentialVerify(vcId: string) {
           };
           setRevealed(sp.revealedFields || null);
           const st = sp.statement;
-          if (st === 'none' || (typeof st === 'object' && st && 'kind' in st)) {
+          const hasSt = typeof st === 'object' && st && 'kind' in st && (st as { kind?: string }).kind !== 'none';
+          const hasProof = typeof sp.proof === 'string' && sp.proof.length > 0;
+          const hasZk = hasSt && hasProof;
+          setHasZkProofInShare(hasZk);
+          if (hasZk) {
             setZkStatement(st as ZkStatement);
           } else {
             setZkStatement(null);
@@ -150,5 +155,5 @@ export function useCredentialVerify(vcId: string) {
     }
   };
 
-  return { verify, revealed, zkValid, zkStatement, reverify, reverifyLoading, hasVerified };
+  return { verify, revealed, zkValid, zkStatement, reverify, reverifyLoading, hasVerified, hasZkProofInShare };
 }

--- a/src/components/modules/credentials/hooks/useShareCredential.ts
+++ b/src/components/modules/credentials/hooks/useShareCredential.ts
@@ -30,6 +30,12 @@ export function useShareCredential(credential: Credential | null) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  useEffect(() => {
+    if (predicate.kind === 'none') {
+      setProof(null);
+    }
+  }, [predicate.kind]);
+
   const onSelectAll = () => {
     if (!credential) return;
     const next: Record<string, boolean> = {};
@@ -65,7 +71,12 @@ export function useShareCredential(credential: Credential | null) {
       try {
         const payload: Record<string, unknown> = { revealedFields };
         if (credential?.id) payload.vc_id = credential.id;
-        if (proof) {
+        if (
+          proof &&
+          proof.statement !== ('none' as ZkStatement) &&
+          typeof proof.proof === 'string' &&
+          proof.proof
+        ) {
           payload.statement = proof.statement as unknown;
           payload.publicSignals = proof.publicSignals as unknown;
           payload.proof = proof.proof as unknown;
@@ -128,7 +139,7 @@ export function useShareCredential(credential: Credential | null) {
     try {
       const kind = predicate.kind;
       if (kind === 'none') {
-        setProof({ statement: 'none', publicSignals: [], proof: null });
+        setProof(null);
       } else {
         if (!credential) {
           setProof({ statement: 'none', publicSignals: [], proof: null });

--- a/src/components/modules/credentials/ui/CredentialVerify.tsx
+++ b/src/components/modules/credentials/ui/CredentialVerify.tsx
@@ -4,8 +4,16 @@ import { CredentialVerifyCard } from './CredentialVerifyCard';
 import { useCredentialVerify } from '@/components/modules/credentials/hooks/useCredentialVerify';
 
 export function CredentialVerify({ vcId }: { vcId: string }) {
-  const { verify, revealed, zkValid, zkStatement, reverify, reverifyLoading, hasVerified, hasZkProofInShare } =
-    useCredentialVerify(vcId);
+  const {
+    verify,
+    revealed,
+    zkValid,
+    zkStatement,
+    reverify,
+    reverifyLoading,
+    hasVerified,
+    hasZkProofInShare,
+  } = useCredentialVerify(vcId);
 
   return (
     <div className="w-full flex flex-col items-center justify-center py-6 gap-6">

--- a/src/components/modules/credentials/ui/CredentialVerify.tsx
+++ b/src/components/modules/credentials/ui/CredentialVerify.tsx
@@ -4,7 +4,7 @@ import { CredentialVerifyCard } from './CredentialVerifyCard';
 import { useCredentialVerify } from '@/components/modules/credentials/hooks/useCredentialVerify';
 
 export function CredentialVerify({ vcId }: { vcId: string }) {
-  const { verify, revealed, zkValid, zkStatement, reverify, reverifyLoading, hasVerified } =
+  const { verify, revealed, zkValid, zkStatement, reverify, reverifyLoading, hasVerified, hasZkProofInShare } =
     useCredentialVerify(vcId);
 
   return (
@@ -18,13 +18,15 @@ export function CredentialVerify({ vcId }: { vcId: string }) {
         zkStatement={zkStatement || null}
         hasVerified={hasVerified}
       />
-      <button
-        onClick={reverify}
-        disabled={reverifyLoading}
-        className="rounded-lg border border-[#edeed1]/30 bg-transparent hover:bg-[#edeed1]/10 text-white px-4 py-2 text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-      >
-        {reverifyLoading ? 'Verifying…' : 'Verify Proof'}
-      </button>
+      {hasZkProofInShare && (
+        <button
+          onClick={reverify}
+          disabled={reverifyLoading}
+          className="rounded-lg border border-[#edeed1]/30 bg-transparent hover:bg-[#edeed1]/10 text-white px-4 py-2 text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {reverifyLoading ? 'Verifying…' : 'Verify Proof'}
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
This pull request refines the handling of proof objects in the `useShareCredential` hook, improving how proofs are managed when the predicate is `'none'` and tightening the conditions for including proof data in payloads. The changes help prevent unnecessary or invalid proof data from being processed or sent.

Proof management improvements:

* Added a `useEffect` to reset the `proof` state to `null` whenever the predicate's kind is `'none'`, ensuring proof data is cleared when not needed.
* Updated logic to set the `proof` state to `null` instead of an object with `'none'` statement and `null` proof when the predicate kind is `'none'`, further standardizing proof handling.

Payload validation enhancements:

* Strengthened the condition for attaching proof data to the payload by checking that the proof exists, its statement is not `'none'`, and its `proof` field is a non-empty string, preventing invalid proofs from being sent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential verification by ensuring the Verify Proof button only appears when a proof is available for verification.
  * Enhanced credential sharing with refined proof validation and handling logic for better data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->